### PR TITLE
Check port occupation for martin service startup

### DIFF
--- a/start_martin_background.bat
+++ b/start_martin_background.bat
@@ -7,6 +7,19 @@ set "SCRIPT_DIR=%~dp0"
 REM 切换到项目目录
 cd /d "%SCRIPT_DIR%"
 
+REM 检查端口3000是否被占用
+echo 🔍 检查端口3000占用情况...
+netstat -an | findstr ":3000 " >nul 2>&1
+if %errorlevel% equ 0 (
+    echo ✅ 端口3000已被占用
+    echo 💡 Martin服务已经在运行中
+    echo 🌐 服务地址: http://localhost:3000
+    echo ❌ 无需重复启动，退出
+    exit /b 0
+) else (
+    echo ✅ 端口3000可用，可以启动Martin服务
+)
+
 REM 从Python配置文件中获取Martin可执行文件路径
 set "MARTIN_EXECUTABLE="
 for /f "tokens=*" %%a in ('python -c "from backend.config import MARTIN_CONFIG; print(MARTIN_CONFIG['martin_executable'])"') do (
@@ -34,8 +47,20 @@ if not exist "martin_config.yaml" (
 REM 使用wmic启动后台进程，不显示窗口
 wmic process call create 'cmd.exe /c "%MARTIN_EXECUTABLE%" --config "%SCRIPT_DIR%martin_config.yaml" > "%SCRIPT_DIR%martin_log.txt" 2>&1' > nul
 
-echo Martin服务已在后台启动
+echo ✅ Martin服务已在后台启动
 echo 可执行文件: %MARTIN_EXECUTABLE%
 echo 配置文件: %SCRIPT_DIR%martin_config.yaml
 echo 日志文件: %SCRIPT_DIR%martin_log.txt
-echo 服务地址: http://localhost:3000 
+echo 服务地址: http://localhost:3000
+
+REM 等待一小段时间后再次检查端口是否被占用，确认启动成功
+timeout /t 2 /nobreak >nul
+echo.
+echo 🔍 验证服务启动状态...
+netstat -an | findstr ":3000 " >nul 2>&1
+if %errorlevel% equ 0 (
+    echo ✅ Martin服务启动成功！端口3000已被占用
+) else (
+    echo ❌ Martin服务启动可能失败，端口3000未被占用
+    echo 💡 请检查日志文件: %SCRIPT_DIR%martin_log.txt
+) 

--- a/start_martin_service.bat
+++ b/start_martin_service.bat
@@ -11,6 +11,34 @@ echo 当前目录: %SCRIPT_DIR%
 REM 切换到项目目录
 cd /d "%SCRIPT_DIR%"
 
+REM 检查端口3000是否被占用
+echo 🔍 检查端口3000占用情况...
+netstat -an | findstr ":3000 " >nul 2>&1
+if %errorlevel% equ 0 (
+    echo ⚠️  警告: 端口3000已被占用
+    echo 💡 Martin服务可能已经在运行中
+    echo 🌐 请访问: http://localhost:3000 确认服务状态
+    echo.
+    echo 选择操作:
+    echo 1. 继续启动 ^(可能失败^)
+    echo 2. 退出
+    set /p choice="请输入选择 (1/2): "
+    if "!choice!"=="2" (
+        echo ❌ 用户选择退出
+        pause
+        exit /b 0
+    )
+    if "!choice!"=="1" (
+        echo ⚠️  继续尝试启动Martin服务...
+    ) else (
+        echo ❌ 无效选择，退出
+        pause
+        exit /b 0
+    )
+) else (
+    echo ✅ 端口3000可用，可以启动Martin服务
+)
+
 REM 从Python配置文件中获取Martin可执行文件路径
 echo 正在从配置文件获取Martin可执行文件路径...
 set "MARTIN_EXECUTABLE="


### PR DESCRIPTION
Add port occupancy checks to Martin service startup scripts to verify service status and prevent redundant starts.

---
<a href="https://cursor.com/background-agent?bcId=bc-2bf53440-d735-451b-bd16-5ff7022095f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2bf53440-d735-451b-bd16-5ff7022095f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>